### PR TITLE
Fix undefined symbol: yywrap issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ env:
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
     - |
       echo ""

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -41,7 +43,22 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line be updated
+# automatically.
+yum install -y flex flex-devel
+
+
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ `uname` == Linux ]; then
+    # Enable -z def linked flag
+    # linking will fail when undefined symbols are present
+    export CFLAGS="${CFLAGS} -Wl,-z,defs"
+fi
 chmod +x configure
 ./configure  --prefix=$PREFIX
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     skip: True  # [win]
-    number: 1
+    number: 2
 
 requirements:
     build:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,2 @@
+flex
+flex-devel


### PR DESCRIPTION
Shared library build with valid yywrap symbol in Linux.  If build in an environment without this symbol the build will fail during the link step.